### PR TITLE
Fix Reconnect Attempts

### DIFF
--- a/smIRCL/Config/IrcConfig.cs
+++ b/smIRCL/Config/IrcConfig.cs
@@ -77,6 +77,11 @@ namespace smIRCL.Config
         public int ReconnectAttempts { get; set; } = 3;
 
         /// <summary>
+        /// The time to wait between connection attempts, in seconds
+        /// </summary>
+        public int ReconnectAttemptWait { get; set; } = 20;
+
+        /// <summary>
         /// Whether to connect immediately during IrcClient instantiation
         /// </summary>
         public bool ConnectOnInstantiation { get; set; } = false;
@@ -171,6 +176,12 @@ namespace smIRCL.Config
             if (ReconnectAttempts < 0)
             {
                 if (throwOnValidationError) throw new Exception($"The parameter '{nameof(ReconnectAttempts)}' is less than 0");
+                isValid = false;
+            }
+
+            if (ReconnectAttemptWait < 0)
+            {
+                if (throwOnValidationError) throw new Exception($"The parameter '{nameof(ReconnectAttemptWait)}' is less than 0");
                 isValid = false;
             }
 

--- a/smIRCL/Core/IrcConnector.cs
+++ b/smIRCL/Core/IrcConnector.cs
@@ -205,8 +205,9 @@ namespace smIRCL.Core
                     _remoteTx = null;
                     _remoteStream = null;
                     _remote = null;
+                    Thread.Sleep(Config.ReconnectAttemptWait * 1000);
                 }
-            } while (!IsConnected && _reconnectAttempts >= Config.ReconnectAttempts);
+            } while (!IsConnected && _reconnectAttempts <= Config.ReconnectAttempts);
 
             if (_reconnectAttempts >= Config.ReconnectAttempts)
             {


### PR DESCRIPTION
Fixed an incorrect comparison operator that was preventing reconnection attempts. Also adds a configurable delay between connection attempts so we don't potentially flood the server - defaulted to 20 seconds.